### PR TITLE
Optimisations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+auto_enums = "0.8.2"
 clap = { version = "4.4.3", features = ["derive","cargo"] }
 which = "5.0.0"
 glob = "0.3.0"

--- a/benchs/benchs.sh
+++ b/benchs/benchs.sh
@@ -4,7 +4,6 @@ echo "generate data"
 # python3 ../scripts/generate_random_fasta.py 1 100000000 100000000 ref_seq.fasta
 # generate some kmers from the ref_seq
 # python3 ../scripts/extract_random_sequences.py --input ref_seq.fasta --min_size 50 --max_size 50 --num 50000 --output compacted_kmers.fasta
-echo ref_set:compacted_kmers.fasta > fof.txt
 
 # Run the benchs
 # generate 10000 100000 1000000 10000000 reads.


### PR DESCRIPTION
Here are a few optimisations:
- remove memory allocations within the cpu-intensive loop
- use 8-bit strings instead of unicode strings
- buffer the output stream (has a performance impact when the number of reads is large)

This yields a ~+90%~+75% speed up ~(however i do not get much gain from the parallel execution, there must be a bottleneck somewhere)~.

I also reordered the output so that it matches the order in the original file (this makes it easy to compare the outputs from different runs).